### PR TITLE
Fix if empty BOM Line is removed

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -383,15 +383,17 @@ frappe.ui.form.on("BOM Item", "items_remove", function(frm) {
 frappe.ui.form.on("BOM Item", "before_items_remove", function(frm, cdt, cdn) {
 	// Remove related Child of child records
 	var d = locals[cdt][cdn];
-	frappe.call({
-		method: 'erpnext.manufacturing.doctype.bom.bom.remove_bomline_alt_items',
-		args: {
-			bom: frm.doc.name,
-			parent_item_code: d.item_code
-		},
-		callback:function(r){
-		}
-	})
+	if (d.item_code) {
+		frappe.call({
+			method: 'erpnext.manufacturing.doctype.bom.bom.remove_bomline_alt_items',
+			args: {
+				bom: frm.doc.name,
+				parent_item_code: d.item_code
+			},
+			callback:function(r){
+			}
+		})
+	}
 });
 
 frappe.ui.form.on("BOM Item", "item_code", function(frm, cdt, cdn) {


### PR DESCRIPTION
Not reported but found it. 

When a empty line is removed and due no "item_code" field throw the error below.

<img width="977" alt="screenshot 2018-05-22 17 22 16" src="https://user-images.githubusercontent.com/5064612/40368605-de30f47a-5de4-11e8-83bd-ca88c8071446.png">
