### PR TITLE
fix:Indentation fixes for python 3

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -614,9 +614,9 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 	# BOM Alternative Items
 	for item, item_details in item_dict.items():
 		item_details['original_item'] = item_details['item_code']
-                if 'set_alternative_items' in item_details.keys():
-                    if item_details['set_alternative_items']:
-			item_details['alt_items'] = get_bomline_alternative_items(bom, item)
+		if 'set_alternative_items' in item_details.keys():
+			if item_details['set_alternative_items']:
+				item_details['alt_items'] = get_bomline_alternative_items(bom, item)
 	return item_dict
 
 @frappe.whitelist()

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -475,8 +475,8 @@ def get_valuation_rate(item_code, warehouse, voucher_type, voucher_no,
 			valuation_rate = frappe.db.get_value('Item Price',
 				dict(item_code=item_code, buying=1, currency=currency),
 				'price_list_rate')
-        if item_code.startswith("K-"): # customer provided
-            allow_zero_rate = True
+		if item_code.startswith("K-"): # customer provided
+			allow_zero_rate = True
 	if not allow_zero_rate and not valuation_rate and raise_error_if_no_rate \
 			and cint(erpnext.is_perpetual_inventory_enabled(company)):
 		frappe.local.message_log = []


### PR DESCRIPTION
Some indentation fixes I faced during bench migrate, since I am on Python 3.

`TabError: inconsistent use of tabs and spaces in indentation`