### PR TITLE
fix(leave alloc): update ledger leaves after submit

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.py
@@ -49,6 +49,9 @@ class LeaveAllocation(Document):
 		if self.carry_forward and allocation:
 			expire_allocation(allocation)
 
+	def on_update_after_submit(self):
+		update_ledger_leaves(self.name, self.total_leaves_allocated)
+
 	def on_cancel(self):
 		self.create_leave_ledger_entry(submit=False)
 		if self.carry_forward:
@@ -221,3 +224,9 @@ def get_unused_leaves(employee, leave_type, from_date, to_date):
 def validate_carry_forward(leave_type):
 	if not frappe.db.get_value("Leave Type", leave_type, "is_carry_forward"):
 		frappe.throw(_("Leave Type {0} cannot be carry-forwarded").format(leave_type))
+
+def update_ledger_leaves(name, total_leaves_allocated):
+	ledger = frappe.get_doc("Leave Ledger Entry", { 'transaction_name': name })
+	ledger.leaves = total_leaves_allocated
+	ledger.save()
+	frappe.db.commit()

--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "creation": "2019-05-09 15:47:39.760406",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -64,6 +63,7 @@
    "options": "transaction_type"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "leaves",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -110,8 +110,7 @@
  ],
  "in_create": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2020-02-27 14:40:10.502605",
+ "modified": "2020-08-06 11:15:00.728247",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Ledger Entry",


### PR DESCRIPTION
Re: https://github.com/newmatik/newmatik/issues/2758

Added a hook so that whenever the `Total Leaves Allocated ` of `Leave Allocation` is updated, it will also update the `Leaves` on the `Leave Ledger Entry` 

![leave](https://user-images.githubusercontent.com/17470909/89602565-9df69400-d899-11ea-9d20-ea378bacf6df.gif)
