### PR TITLE
fix(leave_app): Do not update Leave Ledger on update

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -40,8 +40,7 @@ class LeaveApplication(Document):
 	def on_update(self):
 		if self.status == "Open" and self.docstatus < 1:
 			# notify leave approver about creation
-			self.notify_leave_approver()
-		self.create_leave_ledger_entry()	
+			self.notify_leave_approver()	
 
 	def on_submit(self):
 		if self.status == "Open":


### PR DESCRIPTION
@creamdory The whole culprit is this line of code. Calling create_leave_ledger_entry was causing these issues:

1. Double entry on Approval, 1 because of submitting, another because of update.
2. Even on Reject, it was creating a Leave Ledger which it should not because of calling it on update.

Even in the latest changes refactor from the core, it has been removed. 

Now we only have to correct the existing data.

re: https://github.com/newmatik/newmatik/issues/3486
