### PR TITLE
fix(timesheet): remove company's standard_working_hours

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -94,13 +94,6 @@ frappe.ui.form.on("Timesheet", {
 		}
 	},
 
-	company: function(frm) {
-		frappe.db.get_value('Company', { 'company_name' : frm.doc.company }, 'standard_working_hours')
-			.then(({ message }) => {
-				(frappe.working_hours = message.standard_working_hours || 0);
-			});
-	},
-
 	make_invoice: function(frm) {
 		let dialog = new frappe.ui.Dialog({
 			title: __("Select Item (optional)"),


### PR DESCRIPTION
Removed a part of the code where it is getting the `standard_working_hours` from Company doctype. This results into an error since `standard_working_hours` has been removed with this PR from core https://github.com/frappe/erpnext/pull/22400.