### PR TITLE
fix(Tools): Remove perpetual entry validation

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -131,9 +131,6 @@ def save_entries(gl_map, adv_adj, update_outstanding, from_repost=False):
 		if not from_repost:
 			validate_expense_against_budget(entry)
 
-	if not from_repost:
-		validate_account_for_perpetual_inventory(gl_map)
-
 
 def make_entry(args, adv_adj, update_outstanding, from_repost=False):
 	gle = frappe.new_doc("GL Entry")


### PR DESCRIPTION
Findings so far:
- It turns out Stock Entry Submit is slow for certain type of Stock Entries, even if it from direct Stock Entry.
- If we leave it at Draft it is fine, it is the Submit.
- There are lots of validations and updates that happen on Submit of Stock Entry.
- I drilled down to each one of it and figured the one causing slow down is make_gl_entries.
- Under make_gl_entries there are another set of validations and entries that happen.
- Again had to drill down., came to validate_account_for_perpetual_inventory in General ledger.
- Even though it is not used in version-12, half of the code is commented out from core, this half developed method exists.
- In version-13 it is fixed. But I still doubt that our problem will be solved or not.
- it goes down to method called get_stock_and_account_balance, it gets total stock value for the account (all related warehouse). In our case there are like may be 1000 of them for each account. So it loops over all the 1000 warehouses and get its stock value and add it up. This is the real reason for Stock Entries to be slow.
- For now I am commenting out the half baked code from core, we will have to revisit once we update to version-13 to check if it works after that also or not. I have tested our tools and they are performing fine now with this minor change.

re: https://github.com/newmatik/newmatik/issues/3677